### PR TITLE
Fix path in the ViewsGenerator

### DIFF
--- a/lib/generators/fuel/views_generator.rb
+++ b/lib/generators/fuel/views_generator.rb
@@ -9,7 +9,7 @@ module Fuel
       source_root File.expand_path('../../../../app/views', __FILE__)
 
       def copy_views
-        directory 'fuel', 'app/views/fuel/posts'
+        directory 'fuel', 'app/views/fuel'
       end
 
     end


### PR DESCRIPTION
- Removed unnecessary posts folder from being created in the ViewsGenerator
- This extra folder was causing the generated views to have a different path (`app/views/fuel/posts/admin/authors/_authors.html.erb`) than the paths generated in the routes (`app/views/fuel/admin/authors/_authors.html.erb`), causing the local (app) views to be ignored. 
- This change ensures the views are properly inserted into the application, allowing them to be customizable 
